### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "dist/index.js",
   "type": "commonjs",
   "repository": "github:browserbase/sdk-node",
+  "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [
     "**/*"


### PR DESCRIPTION
The license management tool, [License Finder](https://github.com/pivotal/LicenseFinder), fails to detect the license, so I would like the license to be written in package.json.