### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.14.0",
   "description": "The official Node.js library for the Browserbase API",
   "author": "Browserbase <support@browserbase.com>",
+  "license": "Apache-2.0",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "type": "commonjs",


### PR DESCRIPTION
## Summary
- add Apache-2.0 license metadata to the npm package manifest

## Verification
- node package manifest assertion
- git diff --check
- npm pack --dry-run --ignore-scripts --json