### PR TITLE
fix: let fetch calculate request content length

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -288,24 +288,6 @@ export abstract class APIClient {
     return this.requestAPIList(Page, { method: 'get', path, ...opts });
   }
 
-  private calculateContentLength(body: unknown): string | null {
-    if (typeof body === 'string') {
-      if (typeof Buffer !== 'undefined') {
-        return Buffer.byteLength(body, 'utf8').toString();
-      }
-
-      if (typeof TextEncoder !== 'undefined') {
-        const encoder = new TextEncoder();
-        const encoded = encoder.encode(body);
-        return encoded.length.toString();
-      }
-    } else if (ArrayBuffer.isView(body)) {
-      return body.byteLength.toString();
-    }
-
-    return null;
-  }
-
   async buildRequest<Req>(
     inputOptions: FinalRequestOptions<Req>,
     { retryCount = 0 }: { retryCount?: number } = {},
@@ -319,8 +301,6 @@ export abstract class APIClient {
       : isMultipartBody(options.body) ? options.body.body
       : options.body ? JSON.stringify(options.body, null, 2)
       : null;
-    const contentLength = this.calculateContentLength(body);
-
     const url = this.buildURL(path!, query, defaultBaseURL);
     if ('timeout' in options) validatePositiveInteger('timeout', options.timeout);
     options.timeout = options.timeout ?? this.timeout;
@@ -342,7 +322,7 @@ export abstract class APIClient {
       headers[this.idempotencyHeader] = inputOptions.idempotencyKey;
     }
 
-    const reqHeaders = this.buildHeaders({ options, headers, contentLength, retryCount });
+    const reqHeaders = this.buildHeaders({ options, headers, retryCount });
 
     const req: RequestInit = {
       method,
@@ -360,18 +340,13 @@ export abstract class APIClient {
   private buildHeaders({
     options,
     headers,
-    contentLength,
     retryCount,
   }: {
     options: FinalRequestOptions;
     headers: Record<string, string | null | undefined>;
-    contentLength: string | null | undefined;
     retryCount: number;
   }): Record<string, string> {
     const reqHeaders: Record<string, string> = {};
-    if (contentLength) {
-      reqHeaders['content-length'] = contentLength;
-    }
 
     const defaultHeaders = this.defaultHeaders(options);
     applyHeadersMut(reqHeaders, defaultHeaders);

--- a/tests/content-length.test.ts
+++ b/tests/content-length.test.ts
@@ -1,0 +1,95 @@
+import Browserbase from '@browserbasehq/sdk';
+import type { Fetch, Response } from '@browserbasehq/sdk/core';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+type RequestCapture = {
+  body: string;
+  contentLength: string | undefined;
+};
+
+async function captureRequest(
+  options: { fetch?: Fetch; httpAgent?: http.Agent } = {},
+): Promise<RequestCapture> {
+  let resolveCapture: (capture: RequestCapture) => void;
+  let rejectCapture: (error: Error) => void;
+  const captured = new Promise<RequestCapture>((resolve, reject) => {
+    resolveCapture = resolve;
+    rejectCapture = reject;
+  });
+
+  const server = http.createServer((request, response) => {
+    const chunks: Buffer[] = [];
+
+    request.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    request.on('error', rejectCapture);
+    request.on('aborted', () => rejectCapture(new Error('request aborted before the body was received')));
+    request.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf8');
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{}');
+      resolveCapture({ body, contentLength: request.headers['content-length'] });
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const { port } = server.address() as AddressInfo;
+  const client = new Browserbase({
+    apiKey: 'My API Key',
+    baseURL: `http://127.0.0.1:${port}`,
+    maxRetries: 0,
+    ...options,
+  });
+
+  try {
+    await client.post('/foo', { body: { value: 'café 🌍' } });
+    return await captured;
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+describe('Content-Length on the wire', () => {
+  const prettyBody = JSON.stringify({ value: 'café 🌍' }, null, 2);
+
+  test('native fetch calculates the byte length', async () => {
+    const request = await captureRequest();
+
+    expect(request.body).toBe(prettyBody);
+    expect(request.contentLength).toBe(String(Buffer.byteLength(prettyBody)));
+  });
+
+  test('node-fetch calculates the byte length when an HTTP agent is provided', async () => {
+    const httpAgent = new http.Agent({ keepAlive: false });
+
+    try {
+      const request = await captureRequest({ httpAgent });
+
+      expect(request.body).toBe(prettyBody);
+      expect(request.contentLength).toBe(String(Buffer.byteLength(prettyBody)));
+    } finally {
+      httpAgent.destroy();
+    }
+  });
+
+  test('fetch middleware can transform the body before the byte length is calculated', async () => {
+    const minifyingFetch: Fetch = async (url, init) => {
+      const body = typeof init?.body === 'string' ? JSON.stringify(JSON.parse(init.body)) : init?.body;
+      const nativeInit = { ...init, body } as unknown as Parameters<typeof globalThis.fetch>[1];
+      return (await globalThis.fetch(String(url), nativeInit)) as unknown as Response;
+    };
+
+    const request = await captureRequest({ fetch: minifyingFetch });
+    const minifiedBody = JSON.stringify(JSON.parse(prettyBody));
+
+    expect(request.body).toBe(minifiedBody);
+    expect(request.contentLength).toBe(String(Buffer.byteLength(minifiedBody)));
+  });
+});

--- a/tests/content-length.test.ts
+++ b/tests/content-length.test.ts
@@ -1,5 +1,5 @@
 import Browserbase from '@browserbasehq/sdk';
-import type { Fetch, Response } from '@browserbasehq/sdk/core';
+import type { Fetch } from '@browserbasehq/sdk/core';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 
@@ -19,13 +19,14 @@ async function captureRequest(
   });
 
   const server = http.createServer((request, response) => {
-    const chunks: Buffer[] = [];
+    const chunks: string[] = [];
 
-    request.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    request.setEncoding('utf8');
+    request.on('data', (chunk: string) => chunks.push(chunk));
     request.on('error', rejectCapture);
     request.on('aborted', () => rejectCapture(new Error('request aborted before the body was received')));
     request.on('end', () => {
-      const body = Buffer.concat(chunks).toString('utf8');
+      const body = chunks.join('');
       response.writeHead(200, { 'content-type': 'application/json' });
       response.end('{}');
       resolveCapture({ body, contentLength: request.headers['content-length'] });
@@ -80,10 +81,10 @@ describe('Content-Length on the wire', () => {
   });
 
   test('fetch middleware can transform the body before the byte length is calculated', async () => {
+    const nativeFetch = (globalThis as unknown as { fetch: Fetch }).fetch;
     const minifyingFetch: Fetch = async (url, init) => {
       const body = typeof init?.body === 'string' ? JSON.stringify(JSON.parse(init.body)) : init?.body;
-      const nativeInit = { ...init, body } as unknown as Parameters<typeof globalThis.fetch>[1];
-      return (await globalThis.fetch(String(url), nativeInit)) as unknown as Response;
+      return nativeFetch(url, { ...init, body });
     };
 
     const request = await captureRequest({ fetch: minifyingFetch });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -237,13 +237,23 @@ describe('request building', () => {
   const client = new Browserbase({ apiKey: 'My API Key' });
 
   describe('Content-Length', () => {
-    test('handles multi-byte characters', async () => {
+    test('lets fetch handle multi-byte characters', async () => {
       const { req } = await client.buildRequest({ path: '/foo', method: 'post', body: { value: '—' } });
-      expect((req.headers as Record<string, string>)['content-length']).toEqual('20');
+      expect((req.headers as Record<string, string>)['content-length']).toBeUndefined();
     });
 
-    test('handles standard characters', async () => {
+    test('lets fetch handle standard characters', async () => {
       const { req } = await client.buildRequest({ path: '/foo', method: 'post', body: { value: 'hello' } });
+      expect((req.headers as Record<string, string>)['content-length']).toBeUndefined();
+    });
+
+    test('preserves a caller-provided value', async () => {
+      const { req } = await client.buildRequest({
+        path: '/foo',
+        method: 'post',
+        body: { value: 'hello' },
+        headers: { 'Content-Length': '22' },
+      });
       expect((req.headers as Record<string, string>)['content-length']).toEqual('22');
     });
   });


### PR DESCRIPTION
## Why

The SDK currently calculates `Content-Length` before handing a request to the configured Fetch implementation. That value becomes stale if Fetch middleware transforms the body afterward, and Node's native Fetch then rejects the request with `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH`.

The ordinary session-create JSON path is byte-correct on its own. The compatibility problem is ownership: Fetch already calculates request framing from the final body, and current Stainless-generated TypeScript clients leave that work to the transport.

## What changed

- stop synthesizing `content-length` in the SDK request builder
- preserve an explicitly caller-provided value
- add request-builder and real HTTP wire coverage for native Fetch and the `node-fetch` fallback

## Root cause

The length calculation itself predates the reported regression. SDK 2.14.1 changed modern Node runtimes from `node-fetch` to native `globalThis.fetch`; native Fetch/Undici strictly validates an explicit length against the final bytes. A body-transforming wrapper can therefore expose a stale header that the earlier transport path did not surface. Delegating the header to Fetch makes it calculate the value after those transformations.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `node@22 <harness> local minify` | Middleware changed JSON from 217 to 159 bytes; the SDK supplied no length; native Fetch sent `Content-Length: 159`; server received 159 bytes; PASS. | Reproduces the previously failing stale-header shape and proves the fix on Node 22/Undici 6. |
| `node@24 <harness> local minify` | Middleware changed JSON from 217 to 159 bytes; the SDK supplied no length; native Fetch sent `Content-Length: 159`; server received 159 bytes; PASS. | Proves the same regression path on Node 24/Undici 7. |
| `node@22 <harness> local node-fetch` and `node@24 <harness> local node-fetch` | In both runs, `node-fetch` generated `Content-Length: 217`; server received 217 bytes; PASS. | Covers the fallback transport used on older runtimes and when callers provide a Node HTTP agent. |
| `node@22 jest tests/content-length.test.ts` and `node@24 jest tests/content-length.test.ts` | Three wire-level tests passed on each runtime: native Fetch, the `node-fetch` fallback, and body-transforming middleware. | Keeps the transport behavior and the reproduced regression covered in the repository. |
| `node@22 <local Stagehand 3.7 flow>` and `node@24 <local Stagehand 3.7 flow>` | Real Browserbase `stagehand.init()` created a session and `close()` released it on both runtimes; PASS. | Exercises the exact downstream Stagehand initialization path with the local SDK build and real service. |
| `node@22 <local SDK flow>` and `node@24 <local SDK flow>` | Real Browserbase session create and release succeeded on both runtimes; SDK supplied no explicit length; PASS. | Exercises the changed SDK directly against the live API; no live resource identifiers are included. |
| `node@20 jest --runInBand` with the generated mock API | 22 suites, 140 tests, and 2 snapshots passed. | Full repository regression suite. |
| `npm run build` on Node 20 | CommonJS and ESM builds completed with 0 TypeScript errors; both package import smoke checks passed. | Proves the exact branch produces publishable artifacts in the repository's supported build environment. |
| `npm run lint` | ESLint and TypeScript checks passed. | Supporting static verification. |
