### PR TITLE
fix(client): omit Content-Type on DELETE requests

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -224,7 +224,7 @@ export abstract class APIClient {
   protected defaultHeaders(opts: FinalRequestOptions): Headers {
     return {
       Accept: 'application/json',
-      ...(['head', 'get'].includes(opts.method) ? {} : { 'Content-Type': 'application/json' }),
+      ...(['head', 'get', 'delete'].includes(opts.method) ? {} : { 'Content-Type': 'application/json' }),
       'User-Agent': this.getUserAgent(),
       ...getPlatformHeaders(),
       ...this.authHeaders(opts),

--- a/src/core.ts
+++ b/src/core.ts
@@ -222,9 +222,15 @@ export abstract class APIClient {
    *  }
    */
   protected defaultHeaders(opts: FinalRequestOptions): Headers {
+    // Omit default JSON Content-Type for bodyless methods. DELETE still needs
+    // application/json when the caller sends a body (#180 / Codex follow-up).
+    const omitDefaultContentType =
+      opts.method === 'head' ||
+      opts.method === 'get' ||
+      (opts.method === 'delete' && (opts.body === undefined || opts.body === null));
     return {
       Accept: 'application/json',
-      ...(['head', 'get', 'delete'].includes(opts.method) ? {} : { 'Content-Type': 'application/json' }),
+      ...(omitDefaultContentType ? {} : { 'Content-Type': 'application/json' }),
       'User-Agent': this.getUserAgent(),
       ...getPlatformHeaders(),
       ...this.authHeaders(opts),

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -157,6 +157,19 @@ describe('instantiate client', () => {
     expect(req.headers as Headers).not.toHaveProperty('content-type');
   });
 
+  test('sets Content-Type on DELETE when a JSON body is present', async () => {
+    const client = new Browserbase({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+    });
+    const { req } = await client.buildRequest({
+      path: '/v1/contexts/id',
+      method: 'delete',
+      body: { force: true },
+    });
+    expect((req.headers as Headers)['content-type']).toEqual('application/json');
+  });
+
   test('still sets Content-Type on POST', async () => {
     const client = new Browserbase({
       baseURL: 'http://localhost:5000/',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -148,6 +148,24 @@ describe('instantiate client', () => {
     expect(capturedRequest?.method).toEqual('PATCH');
   });
 
+  test('does not set Content-Type on DELETE (#180)', async () => {
+    const client = new Browserbase({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+    });
+    const { req } = await client.buildRequest({ path: '/v1/contexts/id', method: 'delete' });
+    expect(req.headers as Headers).not.toHaveProperty('content-type');
+  });
+
+  test('still sets Content-Type on POST', async () => {
+    const client = new Browserbase({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+    });
+    const { req } = await client.buildRequest({ path: '/foo', method: 'post', body: { a: 1 } });
+    expect((req.headers as Headers)['content-type']).toEqual('application/json');
+  });
+
   describe('baseUrl', () => {
     test('trailing slash', () => {
       const client = new Browserbase({ baseURL: 'http://localhost:5000/custom/path/', apiKey: 'My API Key' });


### PR DESCRIPTION
## Summary
- `defaultHeaders` previously set `Content-Type: application/json` for every non-GET/HEAD method, including bodyless DELETE.
- That makes `contexts.delete()` fail with `400 Body cannot be empty when content-type is set to 'application/json'` — same class of bug as `extensions.delete()` (#169).
- Exclude `delete` alongside `get`/`head` when applying the default Content-Type (as suggested in #180).

Fixes #180

## Test plan
- [x] Unit tests: DELETE request headers lack `content-type`; POST still gets `application/json`
- [x] A/B: without the core.ts change, DELETE test fails with `content-type: application/json`; with fix, both tests pass

Made with [Cursor](https://cursor.com)